### PR TITLE
Fix storaged access to /sys/block/mmcblk0/stat after 48027a00

### DIFF
--- a/prebuilts/api/29.0/private/compat/26.0/26.0.ignore.cil
+++ b/prebuilts/api/29.0/private/compat/26.0/26.0.ignore.cil
@@ -158,6 +158,7 @@
     statscompanion_service
     storaged_data_file
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_ext4_features
     system_boot_reason_prop
     system_bootstrap_lib_file

--- a/prebuilts/api/29.0/private/compat/27.0/27.0.ignore.cil
+++ b/prebuilts/api/29.0/private/compat/27.0/27.0.ignore.cil
@@ -145,6 +145,7 @@
     storaged_data_file
     super_block_device
     staging_data_file
+    sysfs_disk_stat
     system_boot_reason_prop
     system_bootstrap_lib_file
     system_lmk_prop

--- a/prebuilts/api/29.0/private/compat/28.0/28.0.ignore.cil
+++ b/prebuilts/api/29.0/private/compat/28.0/28.0.ignore.cil
@@ -122,6 +122,7 @@
     simpleperf_app_runner_exec
     su_tmpfs
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_f2fs
     system_bootstrap_lib_file
     system_event_log_tags_file

--- a/prebuilts/api/29.0/private/storaged.te
+++ b/prebuilts/api/29.0/private/storaged.te
@@ -7,6 +7,11 @@ init_daemon_domain(storaged)
 # Read access to pseudo filesystems
 r_dir_file(storaged, domain)
 
+# Allow read access to /sys/block/mmcblk0/stat or /sys/block/sda/stat.
+# Implementations typically have symlinks to vendor specific files.
+# Vendors should mark sysfs_disk_stat on all files read by storaged.
+r_dir_file(storaged, sysfs_disk_stat)
+
 # Read /proc/uid_io/stats
 allow storaged proc_uid_io_stats:file r_file_perms;
 

--- a/prebuilts/api/29.0/public/file.te
+++ b/prebuilts/api/29.0/public/file.te
@@ -11,6 +11,7 @@ type proc_overcommit_memory, fs_type, proc_type;
 type proc_min_free_order_shift, fs_type, proc_type;
 # proc, sysfs, or other nodes that permit configuration of kernel usermodehelpers.
 type usermodehelper, fs_type, proc_type;
+type sysfs_disk_stat, fs_type, sysfs_type;
 type sysfs_usermodehelper, fs_type, sysfs_type;
 type proc_qtaguid_ctrl, fs_type, mlstrustedobject, proc_type;
 type proc_qtaguid_stat, fs_type, mlstrustedobject, proc_type;

--- a/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/26.0/26.0.ignore.cil
@@ -161,6 +161,7 @@
     statscompanion_service
     storaged_data_file
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_ext4_features
     system_boot_reason_prop
     system_bootstrap_lib_file

--- a/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/27.0/27.0.ignore.cil
@@ -148,6 +148,7 @@
     storaged_data_file
     super_block_device
     staging_data_file
+    sysfs_disk_stat
     system_boot_reason_prop
     system_bootstrap_lib_file
     system_lmk_prop

--- a/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/28.0/28.0.ignore.cil
@@ -127,6 +127,7 @@
     socket_hook_prop
     su_tmpfs
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_f2fs
     system_bootstrap_lib_file
     system_event_log_tags_file

--- a/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
+++ b/prebuilts/api/30.0/private/compat/29.0/29.0.ignore.cil
@@ -102,6 +102,7 @@
     staged_install_file
     storage_config_prop
     surfaceflinger_display_prop
+    sysfs_disk_stat
     sysfs_dm_verity
     system_adbd_prop
     system_config_service

--- a/prebuilts/api/30.0/private/storaged.te
+++ b/prebuilts/api/30.0/private/storaged.te
@@ -7,6 +7,11 @@ init_daemon_domain(storaged)
 # Read access to pseudo filesystems
 r_dir_file(storaged, domain)
 
+# Allow read access to /sys/block/mmcblk0/stat or /sys/block/sda/stat.
+# Implementations typically have symlinks to vendor specific files.
+# Vendors should mark sysfs_disk_stat on all files read by storaged.
+r_dir_file(storaged, sysfs_disk_stat)
+
 # Read /proc/uid_io/stats
 allow storaged proc_uid_io_stats:file r_file_perms;
 

--- a/prebuilts/api/30.0/public/file.te
+++ b/prebuilts/api/30.0/public/file.te
@@ -15,6 +15,7 @@ type proc_min_free_order_shift, fs_type, proc_type;
 type proc_kpageflags, fs_type, proc_type;
 # proc, sysfs, or other nodes that permit configuration of kernel usermodehelpers.
 type usermodehelper, fs_type, proc_type;
+type sysfs_disk_stat, fs_type, sysfs_type;
 type sysfs_usermodehelper, fs_type, sysfs_type;
 type proc_qtaguid_ctrl, fs_type, mlstrustedobject, proc_type;
 type proc_qtaguid_stat, fs_type, mlstrustedobject, proc_type;

--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -161,6 +161,7 @@
     statscompanion_service
     storaged_data_file
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_ext4_features
     system_boot_reason_prop
     system_bootstrap_lib_file

--- a/private/compat/27.0/27.0.ignore.cil
+++ b/private/compat/27.0/27.0.ignore.cil
@@ -148,6 +148,7 @@
     storaged_data_file
     super_block_device
     staging_data_file
+    sysfs_disk_stat
     system_boot_reason_prop
     system_bootstrap_lib_file
     system_lmk_prop

--- a/private/compat/28.0/28.0.ignore.cil
+++ b/private/compat/28.0/28.0.ignore.cil
@@ -127,6 +127,7 @@
     socket_hook_prop
     su_tmpfs
     super_block_device
+    sysfs_disk_stat
     sysfs_fs_f2fs
     system_bootstrap_lib_file
     system_event_log_tags_file

--- a/private/compat/29.0/29.0.ignore.cil
+++ b/private/compat/29.0/29.0.ignore.cil
@@ -102,6 +102,7 @@
     staged_install_file
     storage_config_prop
     surfaceflinger_display_prop
+    sysfs_disk_stat
     sysfs_dm_verity
     system_adbd_prop
     system_config_service

--- a/private/storaged.te
+++ b/private/storaged.te
@@ -7,6 +7,11 @@ init_daemon_domain(storaged)
 # Read access to pseudo filesystems
 r_dir_file(storaged, domain)
 
+# Allow read access to /sys/block/mmcblk0/stat or /sys/block/sda/stat.
+# Implementations typically have symlinks to vendor specific files.
+# Vendors should mark sysfs_disk_stat on all files read by storaged.
+r_dir_file(storaged, sysfs_disk_stat)
+
 # Read /proc/uid_io/stats
 allow storaged proc_uid_io_stats:file r_file_perms;
 

--- a/public/file.te
+++ b/public/file.te
@@ -15,6 +15,7 @@ type proc_min_free_order_shift, fs_type, proc_type;
 type proc_kpageflags, fs_type, proc_type;
 # proc, sysfs, or other nodes that permit configuration of kernel usermodehelpers.
 type usermodehelper, fs_type, proc_type;
+type sysfs_disk_stat, fs_type, sysfs_type;
 type sysfs_usermodehelper, fs_type, sysfs_type;
 type proc_qtaguid_ctrl, fs_type, mlstrustedobject, proc_type;
 type proc_qtaguid_stat, fs_type, mlstrustedobject, proc_type;


### PR DESCRIPTION
* Commit "storaged: remove access to sysfs_type" denied the storaged
  daemon access to the sysfs node it needed to do its work.
* It also didn't provide any means necessary for adding the necessary
  rules at a device level, since its sepolicy is private.
* Here we define a new sysfs_disk_stat security label, which device
  maintainers are supposed to add to their genfs_contexts file. This is
  similar to how hal_health_default and sysfs_batteryinfo is handled.
* What prevents the genfs_contexts from being added here directly is
  that in a typical vendor implementation, these sysfs files are
  actually symlinks and not a single, unified path SELinux-wise.

Change-Id: I13ca09cf2458b22ffb6c70b8a353e891e810c606
Signed-off-by: Vladimir Oltean <olteanv@gmail.com>